### PR TITLE
DNM [nrf noup] cmake: Adopted to new multi image approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(util)
 zephyr_library_link_libraries(MCUMGR)
 
 target_link_libraries(MCUMGR INTERFACE
-  ${IMAGE}zephyr_interface
+  zephyr_interface
   TINYCBOR
   )
 


### PR DESCRIPTION
This PR introduces the use of the new principle for creating multi image build.

It reverts the only nordic specific commit, so instead of merging this PR, I suggests that we start following upstream SHA in our manifest.

---------
All occurrences of ${IMAGE} have been removed in order to adopt to the
new strategy used for multi image builds.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>