### PR TITLE
Multi-image upload

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -20,6 +20,9 @@
 #ifndef H_IMG_MGMT_CONFIG_
 #define H_IMG_MGMT_CONFIG_
 
+/* Number of updatable images */
+#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER 1
+
 #if defined MYNEWT
 
 #include "syscfg/syscfg.h"
@@ -37,8 +40,8 @@
 #define IMG_MGMT_LAZY_ERASE     CONFIG_IMG_ERASE_PROGRESSIVELY
 #define IMG_MGMT_DUMMY_HDR      CONFIG_IMG_MGMT_DUMMY_HDR
 #define IMG_MGMT_BOOT_CURR_SLOT 0
-
-#else
+#undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -98,11 +98,13 @@ int img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 
 /**
  * @brief Indicates the type of swap operation that will occur on the next
- * reboot, if any.
+ * reboot, if any, between provided slot and it's pair.
+ * Quering any slots of the same pair will give the same result.
  *
+ * @param image                 An slot number;
  * @return                      An IMG_MGMT_SWAP_TYPE_[...] code.
  */
-int img_mgmt_impl_swap_type(void);
+int img_mgmt_impl_swap_type(int slot);
 
 /**
  * Collects information about the specified image slot.

--- a/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
+++ b/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
@@ -510,8 +510,10 @@ done:
 #endif
 
 int
-img_mgmt_impl_swap_type(void)
+img_mgmt_impl_swap_type(int slot)
 {
+    assert(slot == 0 || slot == 1);
+
     switch (boot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:
         return IMG_MGMT_SWAP_TYPE_NONE;

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -424,7 +424,7 @@ int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len)
 #endif
 
 int
-img_mgmt_impl_swap_type(void)
+img_mgmt_impl_swap_type(int slot)
 {
     switch (mcuboot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -241,7 +241,7 @@ img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash)
     int i;
     struct image_version ver;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, &ver, hash, NULL) != 0) {
             continue;
         }
@@ -262,7 +262,7 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
     int i;
     uint8_t hash[IMAGE_HASH_LEN];
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, ver, hash, NULL) != 0) {
             continue;
         }

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -36,14 +36,12 @@ img_mgmt_state_flags(int query_slot)
     uint8_t flags;
     int swap_type;
 
-    assert(query_slot == 0 || query_slot == 1);
-
     flags = 0;
 
     /* Determine if this is is pending or confirmed (only applicable for
      * unified images and loaders.
      */
-    swap_type = img_mgmt_impl_swap_type();
+    swap_type = img_mgmt_impl_swap_type(query_slot);
     switch (swap_type) {
     case IMG_MGMT_SWAP_TYPE_NONE:
         if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -203,7 +203,8 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
 
     err |= cbor_encoder_create_array(&ctxt->encoder, &images,
                                        CborIndefiniteLength);
-    for (i = 0; i < 2; i++) {
+
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         rc = img_mgmt_read_info(i, &ver, hash, &flags);
         if (rc != 0) {
             continue;
@@ -213,8 +214,13 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
 
         err |= cbor_encoder_create_map(&images, &image,
                                          CborIndefiniteLength);
+
+#if IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 1
+        err |= cbor_encode_text_stringz(&image, "image");
+        err |= cbor_encode_int(&image, i >> 1);
+#endif
         err |= cbor_encode_text_stringz(&image, "slot");
-        err |= cbor_encode_int(&image, i);
+        err |= cbor_encode_int(&image, i % 2);
 
         err |= cbor_encode_text_stringz(&image, "version");
         img_mgmt_ver_str(&ver, vers_str);


### PR DESCRIPTION
Contains upstream (https://github.com/apache/mynewt-mcumgr) PR commits that bring in the multi-image upload to the mcumgr:
 - 932785 zephyr: Add support for multiple images
 - 797f9c Add support for listing and updating two independent images
 - a3d70e Add IMG_MGMT_UPDATABLE_IMAGE_NUMBER configuration option
 - 363eeb Parametrize img_mgmt_impl_swap_type

